### PR TITLE
Update MCXR Play to 1.19.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,16 +3,16 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/use
-	minecraft_version=1.19
-	loader_version=0.14.6
+	minecraft_version=1.19.1
+	loader_version=0.14.9
 
 # Mod Properties
 	core_version = 0.3.0
-	play_version = 0.3.2
+	play_version = 0.3.3
 	maven_group = net.sorenon
 
 # Dependencies
-	fabric_version=0.55.1+1.19
+	fabric_version=0.58.5+1.19.1
 	pehkui_version=3.3.2
 	joml_version=1.10.4
 	night_config_version=3.6.5

--- a/mcxr-play/src/main/java/net/sorenon/mcxr/play/gui/QuickChat.java
+++ b/mcxr-play/src/main/java/net/sorenon/mcxr/play/gui/QuickChat.java
@@ -78,9 +78,9 @@ public class QuickChat extends ChatScreen {
             this.addRenderableWidget(
                     new Button(buttonX, buttonY, buttonWidth, buttonHeight, Component.translatable(word), (button -> {
                         if (word.startsWith("/")) {
-                            Minecraft.getInstance().player.command(word.substring(1));
+                            Minecraft.getInstance().player.commandSigned(word.substring(1), null);
                         } else {
-                            Minecraft.getInstance().player.chat(word);
+                            Minecraft.getInstance().player.chatSigned(word, null);
                         }
 //                        Minecraft.getInstance().gui.getChat().clearMessages(true);
                     }))

--- a/mcxr-play/src/main/resources/fabric.mod.json
+++ b/mcxr-play/src/main/resources/fabric.mod.json
@@ -33,7 +33,7 @@
   "depends": {
     "fabricloader": ">=0.14.6",
     "fabric": "*",
-    "minecraft": "1.19.x",
+    "minecraft": ">=1.19.1",
     "mcxr-core": ">=${core_version}",
     "java": ">=17"
   },


### PR DESCRIPTION
Makes QuickChat use signed messages and fixes the `Error: java.lang.NoSuchMethodError: 'void net.minecraft.class_746.method_3142(java.lang.String)'` error.